### PR TITLE
Update ref-operator-ocp-version.adoc

### DIFF
--- a/downstream/modules/platform/ref-operator-ocp-version.adoc
+++ b/downstream/modules/platform/ref-operator-ocp-version.adoc
@@ -7,5 +7,3 @@
 The {OperatorPlatform} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.10 to 4.13.
 
 [role="_additional-resources"]
-.Additional resources
-* See the link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle] for the most current compatibility details.

--- a/downstream/modules/platform/ref-operator-ocp-version.adoc
+++ b/downstream/modules/platform/ref-operator-ocp-version.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-The {OperatorPlatform} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.9 and later versions.
+The {OperatorPlatform} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.10 to 4.13.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
changed the compatible platform from 4.9 later to 4.10-4.13, matching the life cycle doc and being the correct info